### PR TITLE
⚡ [performance] Move redundant setAdapter and notifyDataSetChanged out of loop

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -163,18 +163,13 @@ public class MainActivity extends AppCompatActivity {
                         Podcast podcast = new Podcast(title, description, pubDate, podcast_type, podcast_url);
                         podcastList.add(podcast);
 
-                        if (mPodcastAdapter == null) {
-                            mPodcastAdapter = new PodcastAdapter(podcastList);
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).setPodcasts(podcastList);
-                        } else {
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).getPodcasts().clear();
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).getPodcasts().addAll(podcastList);
-                            mPodcastAdapter.notifyDataSetChanged();
-                        }
+                    }
 
-
+                    if (mPodcastAdapter == null) {
+                        mPodcastAdapter = new PodcastAdapter(podcastList);
                         mPodcastRecyclerView.setAdapter(mPodcastAdapter);
-
+                    } else {
+                        mPodcastAdapter.notifyDataSetChanged();
                     }
                 }
 


### PR DESCRIPTION
### 💡 What: The optimization implemented
Moved the `mPodcastRecyclerView.setAdapter(mPodcastAdapter)` and `mPodcastAdapter.notifyDataSetChanged()` logic from inside the `for` loop to outside the loop in `MainActivity.java`.

### 🎯 Why: The performance problem it solves
Setting an adapter or notifying it of data changes inside a loop that populates the backing data source causes redundant and expensive UI layout operations for every item added. In Android, each `setAdapter` or `notifyDataSetChanged` call can trigger a full layout pass of the `RecyclerView`. Moving these calls outside the loop ensures the UI is only updated once after the entire data set is ready.

### 📊 Measured Improvement:
While a formal benchmark couldn't be run due to environment limitations (lack of internet for Gradle dependency resolution), this change follows standard Android performance best practices for `RecyclerView`. By reducing the number of layout passes from O(N) to O(1) where N is the number of podcast items, it significantly improves CPU efficiency and reduces UI jank during data loading.


---
*PR created automatically by Jules for task [9845571980903014827](https://jules.google.com/task/9845571980903014827) started by @kgundula*