### PR TITLE
🧹 Remove commented out adapter logic and dead code

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -47,12 +47,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        /*
-        *  When not using DataBinding you would set Activity Layout this way.
-        *
-        * setContentView(R.layout.activity_main);
-        *
-        */
         defensivethinking.co.za.a702podcasts.databinding.ActivityMainBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_main);
         url = Utility.URL;
 
@@ -96,7 +90,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        //unregisterReceiver(podcastIntentServiceReceiver);
     }
 
 
@@ -165,10 +158,7 @@ public class MainActivity extends AppCompatActivity {
 
                         if (mPodcastAdapter == null) {
                             mPodcastAdapter = new PodcastAdapter(podcastList);
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).setPodcasts(podcastList);
                         } else {
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).getPodcasts().clear();
-                            //((defensivethinking.co.za.a702podcasts.a702Podcast) getApplication()).getPodcasts().addAll(podcastList);
                             mPodcastAdapter.notifyDataSetChanged();
                         }
 

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/a702Podcast.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/a702Podcast.java
@@ -3,24 +3,15 @@ package defensivethinking.co.za.a702podcasts;
 import android.app.Application;
 import android.os.StrictMode;
 
-import java.util.List;
-
-import defensivethinking.co.za.a702podcasts.model.Podcast;
-
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.GINGERBREAD;
-
 /**
  * Created by Profusion on 2015-12-14.
  */
 public class a702Podcast extends Application {
 
-    private List<Podcast> mPodcasts;
     @Override
     public void onCreate() {
         super.onCreate();
         enabledStrictMode();
-        //LeakCanary.install(this);
     }
 
     private void enabledStrictMode() {
@@ -29,13 +20,5 @@ public class a702Podcast extends Application {
                 .penaltyLog() //
                 .penaltyDeath() //
                 .build());
-    }
-
-    public List<Podcast> getPodcasts() {
-        return mPodcasts;
-    }
-
-    public void setPodcasts(List<Podcast> mResultsist) {
-        this.mPodcasts = mResultsist;
     }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of obsolete, commented-out adapter logic in `MainActivity.java`.
💡 **Why:** Deleting commented-out obsolete code reduces clutter and improves maintainability and readability. I also identified and removed the "debris" left behind in the supporting `a702Podcast` class (unused fields and methods) to ensure a complete cleanup.
✅ **Verification:** I confirmed that the removed code was either commented out or unused elsewhere in the codebase. I also performed a code review which confirmed the safety and completeness of the changes.
✨ **Result:** A cleaner and more maintainability codebase with reduced clutter and no dead code in the affected areas.

---
*PR created automatically by Jules for task [6500807887500801357](https://jules.google.com/task/6500807887500801357) started by @kgundula*