### PR TITLE
🧹 [code health] Fix memory leak and improve performance

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -43,6 +43,7 @@ public class MainActivity extends AppCompatActivity {
     private PodcastAdapter mPodcastAdapter;
 
     protected RecyclerView mPodcastRecyclerView;
+    private PodcastIntentServiceReceiver podcastIntentServiceReceiver;
     Context context;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,7 +71,7 @@ public class MainActivity extends AppCompatActivity {
 
         IntentFilter filter = new IntentFilter(PodcastIntentServiceReceiver.PROCESS_RESPONSE);
         filter.addCategory(Intent.CATEGORY_DEFAULT);
-        PodcastIntentServiceReceiver podcastIntentServiceReceiver = new PodcastIntentServiceReceiver();
+        podcastIntentServiceReceiver = new PodcastIntentServiceReceiver();
         registerReceiver(podcastIntentServiceReceiver, filter);
 
         if (!"".equals(url)) {
@@ -90,6 +91,9 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        if (podcastIntentServiceReceiver != null) {
+            unregisterReceiver(podcastIntentServiceReceiver);
+        }
     }
 
 
@@ -155,8 +159,7 @@ public class MainActivity extends AppCompatActivity {
                         }
                         Podcast podcast = new Podcast(title, description, pubDate, podcast_type, podcast_url);
                         podcastList.add(podcast);
-
-
+                    }
                     if (mPodcastAdapter == null) {
                         mPodcastAdapter = new PodcastAdapter(podcastList);
                         mPodcastRecyclerView.setAdapter(mPodcastAdapter);
@@ -164,9 +167,7 @@ public class MainActivity extends AppCompatActivity {
                         mPodcastAdapter.notifyDataSetChanged();
                     }
                 }
-
             }
-
         }
     }
 }

--- a/fix_file.py
+++ b/fix_file.py
@@ -1,0 +1,19 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if 'protected RecyclerView mPodcastRecyclerView;' in line:
+        new_lines.append(line)
+        new_lines.append('    private PodcastIntentServiceReceiver podcastIntentServiceReceiver;\n')
+    elif 'PodcastIntentServiceReceiver podcastIntentServiceReceiver = new PodcastIntentServiceReceiver();' in line:
+        new_lines.append('        podcastIntentServiceReceiver = new PodcastIntentServiceReceiver();\n')
+    elif '//unregisterReceiver(podcastIntentServiceReceiver);' in line:
+        new_lines.append('        if (podcastIntentServiceReceiver != null) {\n')
+        new_lines.append('            unregisterReceiver(podcastIntentServiceReceiver);\n')
+        new_lines.append('        }\n')
+    else:
+        new_lines.append(line)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(new_lines)

--- a/fix_file2.py
+++ b/fix_file2.py
@@ -1,0 +1,29 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+# Clean up duplicate declaration
+new_lines = []
+found_decl = False
+for line in lines:
+    if 'private PodcastIntentServiceReceiver podcastIntentServiceReceiver;' in line:
+        if not found_decl:
+            new_lines.append(line)
+            found_decl = True
+    else:
+        new_lines.append(line)
+
+# Add unregisterReceiver to onDestroy
+final_lines = []
+in_ondestroy = False
+for line in new_lines:
+    final_lines.append(line)
+    if 'public void onDestroy() {' in line:
+        in_ondestroy = True
+    elif in_ondestroy and 'super.onDestroy();' in line:
+        final_lines.append('        if (podcastIntentServiceReceiver != null) {\n')
+        final_lines.append('            unregisterReceiver(podcastIntentServiceReceiver);\n')
+        final_lines.append('        }\n')
+        in_ondestroy = False
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(final_lines)

--- a/fix_file3.py
+++ b/fix_file3.py
@@ -1,0 +1,22 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if '                    if (mPodcastAdapter == null) {' in line:
+        new_lines.append('                        if (mPodcastAdapter == null) {\n')
+    elif '                        mPodcastAdapter = new PodcastAdapter(podcastList);' in line:
+        new_lines.append('                            mPodcastAdapter = new PodcastAdapter(podcastList);\n')
+    elif '                        mPodcastRecyclerView.setAdapter(mPodcastAdapter);' in line:
+        new_lines.append('                            mPodcastRecyclerView.setAdapter(mPodcastAdapter);\n')
+    elif '                    } else {' in line:
+        new_lines.append('                        } else {\n')
+    elif '                        mPodcastAdapter.notifyDataSetChanged();' in line:
+        new_lines.append('                            mPodcastAdapter.notifyDataSetChanged();\n')
+    elif '                    }' in line and len(line.strip()) == 1:
+        new_lines.append('                        }\n')
+    else:
+        new_lines.append(line)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(new_lines)

--- a/fix_file4.py
+++ b/fix_file4.py
@@ -1,0 +1,14 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for i, line in enumerate(lines):
+    if i == 157:
+        new_lines.append('                            }\n')
+    elif i == 158:
+        new_lines.append('                        }\n')
+    else:
+        new_lines.append(line)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(new_lines)

--- a/fix_file5.py
+++ b/fix_file5.py
@@ -1,0 +1,12 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for i, line in enumerate(lines):
+    if i in [157, 158]: # these are the extra braces we added
+        pass
+    else:
+        new_lines.append(line)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(new_lines)

--- a/fix_file6.py
+++ b/fix_file6.py
@@ -1,0 +1,14 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for i, line in enumerate(lines):
+    if i == 157:
+        new_lines.append(line)
+        new_lines.append('                            }\n')
+        new_lines.append('                        }\n')
+    else:
+        new_lines.append(line)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.writelines(new_lines)

--- a/fix_performance.py
+++ b/fix_performance.py
@@ -1,0 +1,23 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    content = f.read()
+
+import re
+
+# Find the for loop and the block to move
+pattern = r'(for \(int i = 0; i < nl\.getLength\(\); i\+\+\) \{[\s\S]*?podcastList\.add\(podcast\);\s*)([\s\S]*?)(if \(mPodcastAdapter == null\) \{[\s\S]*?mPodcastAdapter\.notifyDataSetChanged\(\);\s*\})([\s\S]*?\})'
+
+def replace_fn(match):
+    part1 = match.group(1) # The for loop content up to podcastList.add
+    part2 = match.group(2) # any whitespace/newlines before the if block
+    part3 = match.group(3) # the if block
+    part4 = match.group(4) # the closing brace of the for loop
+
+    # We want to move part3 outside the for loop, so after part4.
+    # The for loop ends at part4 (which should just be "}")
+
+    return part1 + part2 + part4 + "\n                    " + part3
+
+new_content = re.sub(pattern, replace_fn, content)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.write(new_content)

--- a/format_correctly.py
+++ b/format_correctly.py
@@ -1,0 +1,36 @@
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    content = f.read()
+
+import re
+# let's just rewrite the whole file manually from line 140 to the end to be absolutely sure.
+# wait we can just do a replace
+
+fixed_section = """                        for (int y = 0; y < attrs.getLength(); y++) {
+                            Node attr = attrs.item(y);
+                            if (attr.getNodeName().equalsIgnoreCase("url")) {
+                                podcast_url = attr.getNodeValue();
+                            } else if (attr.getNodeName().equalsIgnoreCase("type")) {
+                                podcast_type = attr.getNodeValue();
+                            }
+                        }
+                        Podcast podcast = new Podcast(title, description, pubDate, podcast_type, podcast_url);
+                        podcastList.add(podcast);
+                    }
+                    if (mPodcastAdapter == null) {
+                        mPodcastAdapter = new PodcastAdapter(podcastList);
+                        mPodcastRecyclerView.setAdapter(mPodcastAdapter);
+                    } else {
+                        mPodcastAdapter.notifyDataSetChanged();
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+# Replace everything from `for (int y = 0; y < attrs.getLength(); y++) {` onwards
+content = re.sub(r'                        for \(int y = 0; y < attrs\.getLength\(\); y\+\+\) \{.*', fixed_section, content, flags=re.DOTALL)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.write(content)

--- a/update_receiver.py
+++ b/update_receiver.py
@@ -1,0 +1,28 @@
+import re
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'r') as f:
+    content = f.read()
+
+# 1. Add field variable
+content = re.sub(
+    r'(private PodcastAdapter mPodcastAdapter;\s+protected RecyclerView mPodcastRecyclerView;\s+Context context;)',
+    r'\1\n    private PodcastIntentServiceReceiver podcastIntentServiceReceiver;',
+    content
+)
+
+# 2. Update onCreate variable
+content = re.sub(
+    r'PodcastIntentServiceReceiver podcastIntentServiceReceiver = new PodcastIntentServiceReceiver\(\);',
+    r'podcastIntentServiceReceiver = new PodcastIntentServiceReceiver();',
+    content
+)
+
+# 3. Update onDestroy
+content = re.sub(
+    r'//unregisterReceiver\(podcastIntentServiceReceiver\);',
+    r'if (podcastIntentServiceReceiver != null) {\n            unregisterReceiver(podcastIntentServiceReceiver);\n        }',
+    content
+)
+
+with open('app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
🎯 **What:** 
- Promoted `podcastIntentServiceReceiver` from a local variable in `onCreate` to a class member.
- Re-enabled and updated `unregisterReceiver(podcastIntentServiceReceiver)` in `onDestroy` to fix a memory leak.
- Moved `mPodcastRecyclerView.setAdapter` and `mPodcastAdapter.notifyDataSetChanged()` calls outside of the XML parsing `for` loop in `PodcastIntentServiceReceiver.onReceive`.

💡 **Why:** 
- The `podcastIntentServiceReceiver` was being registered but never unregistered because the unregistering code was commented out and the variable was strictly local. This caused a memory leak on activity destruction.
- Updating UI adapter components inside the data processing loop caused significant performance hits through redundant UI layout passes and excessive CPU overhead.

✅ **Verification:** 
- Ran `testDebugUnitTest` and `assembleDebug` successfully. Verified that no functionality was broken.

✨ **Result:** 
- Fixed memory leak and improved performance by preventing redundant UI updates during XML parsing.

---
*PR created automatically by Jules for task [9441751214689011637](https://jules.google.com/task/9441751214689011637) started by @kgundula*