### PR TITLE
🔒 Prevent SSRF by validating intent URL in PodcastService

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import android.util.Log;
 
 import defensivethinking.co.za.a702podcasts.MainActivity;
 
@@ -43,6 +44,11 @@ public class PodcastService extends IntentService {
     protected void onHandleIntent(Intent intent) {
 
         String url = intent.getStringExtra("url");
+        if (url == null || !url.startsWith("https://www.omnycontent.com/")) {
+            Log.w(podcast, "Ignoring intent with untrusted URL: " + url);
+            return;
+        }
+
         String dataXmlStr = "";
         BufferedReader reader = null;
 


### PR DESCRIPTION
🎯 **What:** Fixes a Server-Side Request Forgery vulnerability where `PodcastService` accepts an untrusted URL via Intent and attempts to fetch it without validation.

⚠️ **Risk:** A malicious app could send an Intent containing an arbitrary URL (like an internal server or unexpected file). The vulnerable `PodcastService` would then make an HTTP GET request to this attacker-controlled destination and broadcast the response, potentially exposing sensitive information or facilitating internal scanning.

🛡️ **Solution:** Validate the `url` extra from the Intent in `onHandleIntent`. The code now verifies that the URL starts with the trusted domain `https://www.omnycontent.com/` before processing the request.

---
*PR created automatically by Jules for task [13503126686796405432](https://jules.google.com/task/13503126686796405432) started by @kgundula*