### PR TITLE
🧹 Remove unused REQUEST_METHOD constant in PodcastService

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -22,8 +22,6 @@ public class PodcastService extends IntentService {
 
     public static final int STATUS_FINISHED = 1;
     public static final int STATUS_FAILED = 2;
-;
-    public static final String REQUEST_METHOD  = "request_method";
 
 
     public PodcastService() {


### PR DESCRIPTION
🎯 **What:** Removed the unused `REQUEST_METHOD` constant from `PodcastService.java`.
💡 **Why:** This removes dead code and improves readability and maintainability.
✅ **Verification:** Ran project-wide search (`grep`) to confirm `REQUEST_METHOD` is unused. Compiled project with `./gradlew assembleDebug` and ran tests with `./gradlew testDebugUnitTest`. All checks passed.
✨ **Result:** A cleaner `PodcastService.java` without dead code.

---
*PR created automatically by Jules for task [947733894259363612](https://jules.google.com/task/947733894259363612) started by @kgundula*