### PR TITLE
🧹 [Avoid string concatenation in StringBuffer.append()]

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -60,7 +60,7 @@ public class PodcastService extends IntentService {
 
             String line;
             while ((line = reader.readLine()) != null) {
-                buffer.append(line + "\n");
+                buffer.append(line).append("\n");
             }
 
             if (buffer.length() == 0) {


### PR DESCRIPTION
🎯 **What:** 
Replaced `buffer.append(line + "\n");` with `buffer.append(line).append("\n");` in `PodcastService.java`.

💡 **Why:** 
String concatenation (`+`) inside `StringBuffer.append()` creates an intermediate `StringBuilder` and a new `String` object on every iteration of the `while` loop, adding unnecessary overhead and triggering garbage collection. Chaining `.append()` calls directly utilizes the existing `StringBuffer` more efficiently.

✅ **Verification:** 
I've manually verified the syntax and logic of the change in `PodcastService.java`. Due to environment limitations with Java 21 vs JDK 17 required by the project, unit tests via Gradle could not be executed locally in this environment.

✨ **Result:** 
Reduced intermediate object allocations in `PodcastService.java`, leading to slightly faster XML string building and less GC overhead without changing the logic.

---
*PR created automatically by Jules for task [3191397114281284747](https://jules.google.com/task/3191397114281284747) started by @kgundula*