### PR TITLE
🧪 Add tests for XMLDOMParser error paths

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,5 +40,8 @@ dependencies {
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
     implementation 'com.squareup.okhttp:okhttp:2.6.0'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.mockito:mockito-inline:4.11.0'
+
 
 }

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -170,3 +170,4 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 }
+}

--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
@@ -1,0 +1,59 @@
+package defensivethinking.co.za.a702podcasts.utility;
+
+import android.util.Log;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mockStatic;
+
+public class XMLDOMParserTest {
+
+    private MockedStatic<Log> mockedLog;
+
+    @Before
+    public void setUp() {
+        mockedLog = mockStatic(Log.class);
+        mockedLog.when(() -> Log.e(anyString(), nullable(String.class))).thenReturn(0);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedLog != null) {
+            mockedLog.close();
+        }
+    }
+
+    @Test
+    public void testGetDocument_SAXException() {
+        XMLDOMParser parser = new XMLDOMParser();
+        // A malformed XML string that will throw a SAXException
+        String malformedXml = "<root><unclosed_tag></root>";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(malformedXml.getBytes());
+
+        assertNull(parser.getDocument(inputStream));
+    }
+
+    @Test
+    public void testGetDocument_IOException() {
+        XMLDOMParser parser = new XMLDOMParser();
+        // An InputStream that throws an IOException on read
+        InputStream errorStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("Simulated IOException");
+            }
+        };
+
+        assertNull(parser.getDocument(errorStream));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing Error Path Test for XML Parsing in `XMLDOMParser.getDocument()`.
📊 **Coverage:** Added test cases for SAXException (malformed XML) and IOException (mocked InputStream error).
✨ **Result:** Improved test coverage by verifying the correct handling and return of `null` in case of errors, including correctly mocking `android.util.Log.e`.

---
*PR created automatically by Jules for task [345976013402506640](https://jules.google.com/task/345976013402506640) started by @kgundula*