### PR TITLE
🔒 Fix XXE Vulnerability in XMLDOMParser

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 
 android {
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     compileSdk 34
     defaultConfig {
         applicationId "defensivethinking.co.za.a702podcasts"

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -157,6 +157,8 @@ public class MainActivity extends AppCompatActivity {
                         podcastList.add(podcast);
 
 
+                    }
+
                     if (mPodcastAdapter == null) {
                         mPodcastAdapter = new PodcastAdapter(podcastList);
                         mPodcastRecyclerView.setAdapter(mPodcastAdapter);

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParser.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParser.java
@@ -25,6 +25,16 @@ public class XMLDOMParser {
         Document document = null;
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+        } catch (ParserConfigurationException e) {
+            Log.e("Error: ", "ParserConfigurationException setting features: " + e.getMessage());
+            return null;
+        }
+        try {
             DocumentBuilder db = factory.newDocumentBuilder();
             InputSource inputSource = new InputSource(inputStream);
             document = db.parse(inputSource);

--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
@@ -1,0 +1,81 @@
+package defensivethinking.co.za.a702podcasts.utility;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class XMLDOMParserTest {
+
+    private XMLDOMParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new XMLDOMParser();
+    }
+
+    @Test
+    public void testValidXMLParsing() {
+        String validXML = "<?xml version=\"1.0\"?><podcast><title>My Podcast</title></podcast>";
+        InputStream stream = new ByteArrayInputStream(validXML.getBytes());
+        Document doc = parser.getDocument(stream);
+
+        assertNotNull("Document should not be null for valid XML", doc);
+        NodeList nodes = doc.getElementsByTagName("title");
+        assertEquals(1, nodes.getLength());
+        assertEquals("My Podcast", parser.getNodeValue(nodes.item(0)));
+    }
+
+    @Test
+    public void testXXEVulnerabilityPrevention() {
+        // This XML attempts to use an external entity.
+        // If the parser is vulnerable, it might try to read /etc/passwd (or throw a specific error).
+        // If DOCTYPE is disallowed, parsing should fail entirely.
+        String maliciousXML = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "  <!ELEMENT foo ANY >\n" +
+                "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n" +
+                "<foo>&xxe;</foo>";
+
+        InputStream stream = new ByteArrayInputStream(maliciousXML.getBytes());
+        Document doc = parser.getDocument(stream);
+
+        // Since we disallow DOCTYPE, parsing this XML should fail and return null
+        assertNull("Document should be null for XML containing DOCTYPE when DOCTYPE is disallowed", doc);
+    }
+
+    @Test
+    public void testBillionLaughsVulnerabilityPrevention() {
+        // This XML attempts a Billion Laughs attack (entity expansion).
+        // Since we disable entity expansion and DOCTYPE, this should fail.
+        String maliciousXML = "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE lolz [\n" +
+                " <!ENTITY lol \"lol\">\n" +
+                " <!ELEMENT lolz (#PCDATA)>\n" +
+                " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n" +
+                " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n" +
+                " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n" +
+                " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n" +
+                " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n" +
+                " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n" +
+                " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n" +
+                " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n" +
+                " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n" +
+                "]>\n" +
+                "<lolz>&lol9;</lolz>";
+
+        InputStream stream = new ByteArrayInputStream(maliciousXML.getBytes());
+        Document doc = parser.getDocument(stream);
+
+        // Parsing should fail and return null
+        assertNull("Document should be null for XML attempting entity expansion attacks when DOCTYPE is disallowed", doc);
+    }
+}


### PR DESCRIPTION
🎯 What:
The XMLDOMParser previously used the default DocumentBuilderFactory without disabling DOCTYPE declarations or external entities. This left the application vulnerable to XML External Entity (XXE) and entity expansion (Billion Laughs) attacks.

⚠️ Risk:
If the application parses untrusted XML feeds containing malicious entities, an attacker could potentially read local files, trigger server-side request forgery (SSRF), or cause a denial of service (DoS) through entity expansion.

🛡️ Solution:
* Explicitly configured DocumentBuilderFactory to disallow DOCTYPE declarations (disallow-doctype-decl).
* Disabled external general and parameter entities as an additional defense-in-depth measure.
* Disabled XInclude and entity expansion to prevent DoS attacks.
* Added specific unit tests to verify both XXE and Billion Laughs payloads are successfully mitigated.
* Fixed an unmatched bracket formatting issue in MainActivity caught during Gradle builds.

---
*PR created automatically by Jules for task [10014783039799250068](https://jules.google.com/task/10014783039799250068) started by @kgundula*