### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: Android CI/CD
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -63,6 +66,8 @@ jobs:
     name: Release APK
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kgundula/702Podcasts/security/code-scanning/4](https://github.com/kgundula/702Podcasts/security/code-scanning/4)

Generally, the problem is fixed by explicitly declaring a `permissions` block in the workflow to restrict the default `GITHUB_TOKEN` permissions to the minimum required, rather than relying on repository defaults. Jobs that only read code or artifacts should typically use `contents: read`, while jobs that must create releases or otherwise modify repository contents should declare `contents: write` (or other specific write scopes) at the job level.

For this workflow, the `test` and `build` jobs only check out code, run Gradle, and upload artifacts; they do not need to modify repository contents. The `release` job needs to create a GitHub Release via `softprops/action-gh-release@v2`, which requires `contents: write`. The best non-functional-change fix is therefore:
- Add a root-level `permissions` block after `name:` (or after `on:`) setting `contents: read` so all jobs default to read-only repository access.
- Add a `permissions` block to the `release` job setting `contents: write` to allow creating releases.
No additional imports or dependencies are needed, and no other workflow logic changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
