### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Unit Tests
@@ -63,6 +66,8 @@ jobs:
     name: Release APK
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kgundula/702Podcasts/security/code-scanning/3](https://github.com/kgundula/702Podcasts/security/code-scanning/3)

In general, the fix is to declare an explicit `permissions` block instead of relying on repository/organization defaults. We should grant only what each job needs. For this workflow:  
- `test` and `build` jobs only need to read repository contents (for `actions/checkout`), so they can use `contents: read`.  
- `release` also needs to create a GitHub Release via `softprops/action-gh-release@v2`, which uses `contents: write` on the `GITHUB_TOKEN`.

The cleanest fix without changing existing behavior is:  
- Add a workflow-level `permissions: contents: read` near the top (after `name` or `on:`) to apply read-only by default to all jobs.  
- Override in the `release` job with a job-level `permissions:` block that sets `contents: write`.

This leaves the logic and steps of each job unchanged, and simply constrains the token’s capabilities. No imports or external dependencies are required, as this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
