### PR TITLE
⚡ Use StringBuilder instead of StringBuffer in PodcastService

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -61,31 +61,28 @@ public class PodcastService extends IntentService {
         }
 
         String dataXmlStr = "";
-        BufferedReader reader = null;
 
         //final String rec = intent.getStringExtra("receiver");
+        HttpURLConnection con = null;
         try {
-            HttpURLConnection con = (HttpURLConnection) (new URL(url)).openConnection();
+            con = (HttpURLConnection) (new URL(url)).openConnection();
             con.setRequestMethod("GET");
             con.connect();
-            InputStream inputStream = con.getInputStream();
-            StringBuilder buffer = new StringBuilder();
-            if (inputStream == null) {
-                return;
-            }
-            reader = new BufferedReader(new InputStreamReader(inputStream));
 
-            String line;
-            while ((line = reader.readLine()) != null) {
-                buffer.append(line).append("\n");
-            }
+            try (InputStream inputStream = con.getInputStream();
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+                StringBuilder buffer = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    buffer.append(line).append("\n");
+                }
 
-            if (buffer.length() == 0) {
-                return;
-            }
+                if (buffer.length() == 0) {
+                    return;
+                }
 
-            dataXmlStr = buffer.toString();
-            inputStream.close();
+                dataXmlStr = buffer.toString();
+            }
 
             // Parse the XML here to avoid TransactionTooLargeException in broadcast
             XMLDOMParser parser = new XMLDOMParser();
@@ -130,6 +127,10 @@ public class PodcastService extends IntentService {
 
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            if (con != null) {
+                con.disconnect();
+            }
         }
 
         Intent broadcastIntent = new Intent();

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -69,7 +69,7 @@ public class PodcastService extends IntentService {
             con.setRequestMethod("GET");
             con.connect();
             InputStream inputStream = con.getInputStream();
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder buffer = new StringBuilder();
             if (inputStream == null) {
                 return;
             }


### PR DESCRIPTION
- [x] Replace `StringBuffer` with `StringBuilder`
- [x] Fix resource leaks: use try-with-resources for `InputStream`/`BufferedReader` and `finally` block to always call `con.disconnect()`