### PR TITLE
🔒 [security fix] Sensitive Information Leakage via printStackTrace

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -129,7 +129,7 @@ public class PodcastService extends IntentService {
             Log.d("PodcastService", "Cache updated with " + podcastList.size() + " podcasts");
 
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.e("PodcastService", "Error handling podcast intent", e);
         }
 
         Intent broadcastIntent = new Intent();

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParser.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParser.java
@@ -43,12 +43,10 @@ public class XMLDOMParser {
             document = db.parse(inputSource);
 
         } catch (ParserConfigurationException | SAXException | IOException e) {
-            Log.e("XMLDOMParser", "Error parsing XML: " + e.getMessage());
-            e.printStackTrace();
+            Log.e("XMLDOMParser", "Error parsing XML", e);
             return null;
         } catch (Exception e) {
-            Log.e("XMLDOMParser", "Unexpected error: " + e.getMessage());
-            e.printStackTrace();
+            Log.e("XMLDOMParser", "Unexpected error", e);
             return null;
         }
         return document;


### PR DESCRIPTION
🎯 **What:** Replaced `e.printStackTrace()` with secure logging in `XMLDOMParser.java` and `PodcastService.java`.
⚠️ **Risk:** Leakage of internal application details (e.g., file paths, library versions) via standard output/error, which can be exploited by attackers to understand the application structure and find more vulnerabilities.
🛡️ **Solution:** Substituted `e.printStackTrace()` with `Log.e()` using the `(String tag, String msg, Throwable tr)` overload to maintain diagnostic information while adhering to Android's secure logging practices. Verified the implementation by manual inspection of the codebase to ensure correct variable usage and scope.

---
*PR created automatically by Jules for task [15319028263617723349](https://jules.google.com/task/15319028263617723349) started by @kgundula*