### PR TITLE
🧪 [testing improvement] Add unit tests for XMLDOMParser.getNodeAttr

### DIFF
--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
@@ -6,11 +6,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -55,5 +60,27 @@ public class XMLDOMParserTest {
         };
 
         assertNull(parser.getDocument(errorStream));
+    }
+
+    @Test
+    public void testGetNodeAttr() throws Exception {
+        XMLDOMParser parser = new XMLDOMParser();
+        String xml = "<item id=\"123\" category=\"podcast\" />";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+        Node node = doc.getDocumentElement();
+
+        // Test existing attribute
+        assertEquals("123", parser.getNodeAttr("id", node));
+
+        // Test case-insensitive
+        assertEquals("123", parser.getNodeAttr("ID", node));
+
+        // Test another attribute
+        assertEquals("podcast", parser.getNodeAttr("category", node));
+
+        // Test non-existent attribute
+        assertEquals("", parser.getNodeAttr("nonexistent", node));
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `XMLDOMParser.getNodeAttr(String, Node)` has been addressed.
📊 **Coverage:** The new test covers:
- Successful attribute retrieval.
- Case-insensitive matching of attribute names.
- Retrieval from nodes with multiple attributes.
- Handling of non-existent attributes (returns empty string).
✨ **Result:** Improved test coverage for the core XML parsing utility, ensuring its reliability when extracting metadata from podcast feeds.

---
*PR created automatically by Jules for task [5840510854709039881](https://jules.google.com/task/5840510854709039881) started by @kgundula*