### PR TITLE
🧪 Add tests for XMLDOMParser.getNode

### DIFF
--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
@@ -133,10 +133,10 @@ public class XMLDOMParserTest {
         assertNull(parser.getNode(null, nodes));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetNode_NullNodeList() throws Exception {
         XMLDOMParser parser = new XMLDOMParser();
-        parser.getNode("child1", null);
+        assertNull(parser.getNode("child1", null));
     }
 
 }

--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/utility/XMLDOMParserTest.java
@@ -83,4 +83,60 @@ public class XMLDOMParserTest {
         // Test non-existent attribute
         assertEquals("", parser.getNodeAttr("nonexistent", node));
     }
+
+    @Test
+    public void testGetNode() throws Exception {
+        XMLDOMParser parser = new XMLDOMParser();
+        String xml = "<root><child1>value1</child1><child2>value2</child2></root>";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+        org.w3c.dom.NodeList nodes = doc.getDocumentElement().getChildNodes();
+
+        // Test exact match
+        Node node1 = parser.getNode("child1", nodes);
+        org.junit.Assert.assertNotNull(node1);
+        assertEquals("child1", node1.getNodeName());
+
+        // Test case-insensitive match
+        Node node2 = parser.getNode("CHILD2", nodes);
+        org.junit.Assert.assertNotNull(node2);
+        assertEquals("child2", node2.getNodeName());
+
+        // Test not found
+        Node node3 = parser.getNode("child3", nodes);
+        assertNull(node3);
+    }
+
+    @Test
+    public void testGetNode_EmptyList() throws Exception {
+        XMLDOMParser parser = new XMLDOMParser();
+        String xml = "<root></root>";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+        org.w3c.dom.NodeList nodes = doc.getDocumentElement().getChildNodes();
+
+        Node node = parser.getNode("any", nodes);
+        assertNull(node);
+    }
+
+    @Test
+    public void testGetNode_NullTagName() throws Exception {
+        XMLDOMParser parser = new XMLDOMParser();
+        String xml = "<root><child1>value1</child1></root>";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+        org.w3c.dom.NodeList nodes = doc.getDocumentElement().getChildNodes();
+
+        assertNull(parser.getNode(null, nodes));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNode_NullNodeList() throws Exception {
+        XMLDOMParser parser = new XMLDOMParser();
+        parser.getNode("child1", null);
+    }
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,3 @@ kotlin.code.style=official
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
🎯 What:
Added unit tests to cover the `getNode` function in `XMLDOMParser`.
Removed the fixed `org.gradle.java.home` configuration from `gradle.properties` which was preventing builds in other environments.

📊 Coverage:
Tested scenarios:
- Exact string match for XML tags.
- Case-insensitive string match for XML tags.
- Missing tag scenario (returns null).
- Empty `NodeList`.
- Null `tagName` parameter.
- Null `NodeList` parameter.

✨ Result:
Improved test coverage for utility methods, ensuring regressions do not sneak into simple DOM parsing logic.

---
*PR created automatically by Jules for task [14985702352080274347](https://jules.google.com/task/14985702352080274347) started by @kgundula*