### PR TITLE
🔒 Fix sensitive info leakage via printStackTrace

### DIFF
--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
@@ -12,11 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import defensivethinking.co.za.a702podcasts.service.PodcastService;
-
 public class PodcastServiceTest {
 
     private MockedStatic<Log> mockedLog;

--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
@@ -1,0 +1,52 @@
+package defensivethinking.co.za.a702podcasts.service;
+
+import android.content.Intent;
+import android.util.Log;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import defensivethinking.co.za.a702podcasts.service.PodcastService;
+
+public class PodcastServiceTest {
+
+    private MockedStatic<Log> mockedLog;
+
+    @Before
+    public void setUp() {
+        mockedLog = mockStatic(Log.class);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedLog != null) {
+            mockedLog.close();
+        }
+    }
+
+    @Test
+    public void testOnHandleIntent_logsException_whenMalformedUrl() {
+        // Setup
+        PodcastService service = new PodcastService();
+        Intent mockIntent = mock(Intent.class);
+
+        // Return a malformed URL to trigger an exception
+        when(mockIntent.getStringExtra("url")).thenReturn("https://www.omnycontent.com/malformed-url-that-does-not-exist");
+
+        // The method protected void onHandleIntent(Intent intent) needs to be accessed
+        // We can either change visibility for testing, or use reflection, or call it directly if it's package-private / protected and we are in same package
+        service.onHandleIntent(mockIntent);
+
+        // Verify Log.e was called with the specific tag and message and any exception
+        mockedLog.verify(() -> Log.e(eq("PodcastService"), eq("Error handling podcast intent"), any(Exception.class)));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Replaced `e.printStackTrace()` with `Log.e()` in `PodcastService` and added a unit test to verify the logging behavior. (Note: The `Log.e()` fix was already present in the codebase, so the primary contribution here is the unit test).
⚠️ **Risk:** `printStackTrace()` can leak sensitive information to system logs, potentially exposing stack traces that reveal application architecture or sensitive variables.
🛡️ **Solution:** Use a secure logging framework (`android.util.Log`) with an appropriate log level (Error) and tag, which provides better control over log output in production environments and prevents unintended leakage. The test uses Mockito `mockStatic` to ensure this behavior is enforced.

---
*PR created automatically by Jules for task [3091326809436201494](https://jules.google.com/task/3091326809436201494) started by @kgundula*