### PR TITLE
🔒 Prevent untrusted user input logging in PodcastService

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/service/PodcastService.java
@@ -65,12 +65,12 @@ public class PodcastService extends IntentService {
         String host = parsedUri.getHost();
 
         if (scheme == null || scheme.isEmpty() || host == null || host.isEmpty()) {
-            Log.w(podcast, "Ignoring intent with unparseable URL: " + url);
+            Log.w(podcast, "Ignoring intent with unparseable URL");
             return;
         }
 
         if (!"https".equals(scheme) || !"www.omnycontent.com".equals(host)) {
-            Log.w(podcast, "Ignoring intent with untrusted URL: " + url);
+            Log.w(podcast, "Ignoring intent with untrusted URL");
             return;
         }
         String dataXmlStr = "";

--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/service/PodcastServiceTest.java
@@ -45,4 +45,28 @@ public class PodcastServiceTest {
         // Verify Log.e was called with the specific tag and message and any exception
         mockedLog.verify(() -> Log.e(eq("PodcastService"), eq("Error handling podcast intent"), any(Exception.class)));
     }
+
+    @Test
+    public void testOnHandleIntent_logsWarningWithoutUrl_whenUnparseableUrl() {
+        PodcastService service = new PodcastService();
+        Intent mockIntent = mock(Intent.class);
+        String untrustedUrl = "malformed-url";
+        when(mockIntent.getStringExtra("url")).thenReturn(untrustedUrl);
+
+        service.onHandleIntent(mockIntent);
+
+        mockedLog.verify(() -> Log.w(eq(PodcastService.podcast), eq("Ignoring intent with unparseable URL")));
+    }
+
+    @Test
+    public void testOnHandleIntent_logsWarningWithoutUrl_whenUntrustedUrl() {
+        PodcastService service = new PodcastService();
+        Intent mockIntent = mock(Intent.class);
+        String untrustedUrl = "https://untrusted.com/podcast.xml";
+        when(mockIntent.getStringExtra("url")).thenReturn(untrustedUrl);
+
+        service.onHandleIntent(mockIntent);
+
+        mockedLog.verify(() -> Log.w(eq(PodcastService.podcast), eq("Ignoring intent with untrusted URL")));
+    }
 }


### PR DESCRIPTION
🎯 **What:** Removed untrusted `url` variable from log statements in `PodcastService.java`.
⚠️ **Risk:** Logging untrusted user input can lead to log injection/forgery attacks, where an attacker can manipulate log entries by providing URLs containing control characters like newlines.
🛡️ **Solution:** The untrusted `url` is removed from the `Log.w` messages when the URL is unparseable or untrusted. Added regression tests in `PodcastServiceTest.java`.

---
*PR created automatically by Jules for task [10958504793168586794](https://jules.google.com/task/10958504793168586794) started by @kgundula*