### PR TITLE
🧹 Remove unused imports from MainActivity.java

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/MainActivity.java
@@ -18,25 +18,15 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.util.Log;
 import android.view.View;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
 import defensivethinking.co.za.a702podcasts.adapters.PodcastAdapter;
-import defensivethinking.co.za.a702podcasts.databinding.ActivityMainBinding;
 import defensivethinking.co.za.a702podcasts.listener.RecyclerItemClickListener;
 import defensivethinking.co.za.a702podcasts.model.Podcast;
 import defensivethinking.co.za.a702podcasts.service.PodcastService;
 import defensivethinking.co.za.a702podcasts.utility.RecylerViewDividerItemDecoration;
 import defensivethinking.co.za.a702podcasts.utility.Utility;
-import defensivethinking.co.za.a702podcasts.utility.XMLDOMParser;
 
 public class MainActivity extends AppCompatActivity {
     String url = "";


### PR DESCRIPTION
🎯 **What:** Removed several unused imports from `MainActivity.java`, including `XMLDOMParser`, `org.w3c.dom.*` classes, `java.io.*` classes, and `ActivityMainBinding`.

💡 **Why:** Removing unused imports improves code readability and maintainability by reducing clutter and potential namespace conflicts.

✅ **Verification:** 
- Performed manual code analysis to ensure none of the removed classes are used in the file's body.
- Used a script to verify no occurrences of the class names existed outside the import section.
- Confirmed `ActivityMainBinding` is used via its fully qualified name, making the import redundant.
- Confirmed `XMLDOMParser` is still used in `PodcastService.java`, so it is not dead code.

✨ **Result:** A cleaner and more maintainable `MainActivity.java`.

---
*PR created automatically by Jules for task [17623202721912984995](https://jules.google.com/task/17623202721912984995) started by @kgundula*