### PR TITLE
🔒 fix: set android:exported="false" for internal components

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,10 +21,13 @@
             </intent-filter>
         </activity>
 
-        <service android:name=".service.PodcastService" />
+        <service
+            android:name=".service.PodcastService"
+            android:exported="false" />
 
         <activity
             android:name=".PodcastDetailActivity"
+            android:exported="false"
             android:label="@string/title_activity_podast_detail"
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar">


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the unsafe export of internal application components (`PodcastDetailActivity` and `PodcastService`) in the `AndroidManifest.xml`.

⚠️ **Risk:** By default, or if not explicitly set to `false`, these components could be accessible to other applications installed on the device. This could allow a malicious app to launch the `PodcastDetailActivity` directly or interact with the `PodcastService`, potentially leading to unauthorized access to application data or functionality.

🛡️ **Solution:** I have explicitly set `android:exported="false"` for both `PodcastDetailActivity` and `PodcastService` in `app/src/main/AndroidManifest.xml`. This ensures that these components can only be launched or bound by the application itself or by components with the same user ID.

---
*PR created automatically by Jules for task [11858836652550704486](https://jules.google.com/task/11858836652550704486) started by @kgundula*