### PR TITLE
🔒 Disable insecure allowBackup configuration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
🎯 **What:** The `android:allowBackup` attribute in `AndroidManifest.xml` was set to `true`, which is insecure.
⚠️ **Risk:** This configuration can lead to data leakage if a malicious user gains physical access to an unlocked device or if a malicious app has access to the device's backup.
🛡️ **Solution:** Changed `android:allowBackup` to `false` in `app/src/main/AndroidManifest.xml` to prevent unauthorized data extraction via backup mechanisms.

---
*PR created automatically by Jules for task [9048993462804632592](https://jules.google.com/task/9048993462804632592) started by @kgundula*