### PR TITLE
🧪 Add tests for Podcast constructors

### DIFF
--- a/app/src/test/java/defensivethinking/co/za/a702podcasts/model/PodcastTest.java
+++ b/app/src/test/java/defensivethinking/co/za/a702podcasts/model/PodcastTest.java
@@ -1,0 +1,34 @@
+package defensivethinking.co.za.a702podcasts.model;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class PodcastTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        Podcast podcast = new Podcast();
+        assertEquals("", podcast.getItemTitle());
+        assertEquals("", podcast.getItemDescription());
+        assertEquals("", podcast.getItemPubDate());
+        assertEquals("", podcast.getItemType());
+        assertEquals("", podcast.getItemUrl());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        String title = "Test Title";
+        String description = "Test Description";
+        String pubDate = "2023-10-27";
+        String type = "audio/mpeg";
+        String url = "https://example.com/podcast.mp3";
+
+        Podcast podcast = new Podcast(title, description, pubDate, type, url);
+
+        assertEquals(title, podcast.getItemTitle());
+        assertEquals(description, podcast.getItemDescription());
+        assertEquals(pubDate, podcast.getItemPubDate());
+        assertEquals(type, podcast.getItemType());
+        assertEquals(url, podcast.getItemUrl());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `Podcast` model class, covering both the default and parameterized constructors.
📊 **Coverage:**
- Default constructor: ensures fields are initialized to empty strings.
- Parameterized constructor: ensures fields are correctly initialized from the provided arguments.
- Verified all getter methods return the expected values.
✨ **Result:** Improved test coverage for the `Podcast` model, ensuring that object instantiation is reliable and correctly handled.

---
*PR created automatically by Jules for task [13745502450283844219](https://jules.google.com/task/13745502450283844219) started by @kgundula*