### PR TITLE
Implement Listen Now button action in HomeScreen

### DIFF
--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
@@ -81,7 +81,7 @@ fun TopBar() {
 }
 
 @Composable
-fun FeaturedPodcastCard(onListenNow: () -> Unit) {
+fun FeaturedPodcastCard(onListenNow: () -> Unit = {}) {
     Box(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
@@ -38,7 +38,9 @@ fun HomeScreen(navController: NavController) {
             TopBar()
         }
         item {
-            FeaturedPodcastCard()
+            FeaturedPodcastCard(
+                onListenNow = { navController.navigate("details/echoes-of-the-digital-frontier") }
+            )
         }
         item {
             ContinueListeningSection()
@@ -79,7 +81,7 @@ fun TopBar() {
 }
 
 @Composable
-fun FeaturedPodcastCard() {
+fun FeaturedPodcastCard(onListenNow: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -134,7 +136,7 @@ fun FeaturedPodcastCard() {
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(
-                onClick = { /* TODO */ },
+                onClick = onListenNow,
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
                 Text("Listen Now", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold)

--- a/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/defensivethinking/co/za/a702podcasts/ui/screens/HomeScreen.kt
@@ -39,7 +39,11 @@ fun HomeScreen(navController: NavController) {
         }
         item {
             FeaturedPodcastCard(
-                onListenNow = { navController.navigate("details/echoes-of-the-digital-frontier") }
+                onListenNow = {
+                    navController.navigate("details/echoes-of-the-digital-frontier") {
+                        launchSingleTop = true
+                    }
+                }
             )
         }
         item {


### PR DESCRIPTION
The 'Listen Now' button in the `FeaturedPodcastCard` on the `HomeScreen` was previously a TODO. This change implements the button's `onClick` action by:
1.  **State Hoisting**: Updating the `FeaturedPodcastCard` composable to accept an `onListenNow: () -> Unit` lambda parameter.
2.  **Navigation**: Passing a lambda from the `HomeScreen` composable that uses the `NavController` to navigate to the `details/{podcastId}` route with a hardcoded ID for the featured podcast (`echoes-of-the-digital-frontier`).

This follows existing patterns in the codebase where navigation is centralized in the screen-level composables.

---
*PR created automatically by Jules for task [12914645874469362799](https://jules.google.com/task/12914645874469362799) started by @kgundula*