### PR TITLE
🔒 Disable unsafe cleartext network traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true">


### PR DESCRIPTION
🎯 **What:** Fixed the "Unsafe Cleartext Network Traffic Permitted" vulnerability by adding `android:usesCleartextTraffic="false"` to the `<application>` tag in `app/src/main/AndroidManifest.xml`.

⚠️ **Risk:** Allowing cleartext traffic permits the application to communicate over unencrypted HTTP. This exposes users to man-in-the-middle (MITM) attacks where sensitive data can be intercepted or tampered with by attackers on the same network.

🛡️ **Solution:** By setting `android:usesCleartextTraffic="false"`, the Android system will prevent the app from using cleartext HTTP, forcing the use of secure, encrypted HTTPS for all network communications.

---
*PR created automatically by Jules for task [16703630197052816223](https://jules.google.com/task/16703630197052816223) started by @kgundula*